### PR TITLE
Correct copyright statement in LICENSE file

### DIFF
--- a/Code/LICENSE
+++ b/Code/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 The Python Packaging Authority
+Copyright (c) 2019-2020 Cardiff University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR corrects the copyright statement in the `LICENSE` file.