### PR TITLE
Symlink LICENSE to top-level

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+Code/LICENSE


### PR DESCRIPTION
This PR adds a symlink from `Code/LICENSE` -> `LICENSE` so that github recognises the license for this work, and adds a the relevant license badge on repository front page, see [here](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/licensing-a-repository#detecting-a-license) for details. 