### PR TITLE
Add setup_requires and install_requires to setup.py

### DIFF
--- a/Code/setup.py
+++ b/Code/setup.py
@@ -18,5 +18,15 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    setup_requires=[
+        "setuptools",
+    ],
+    install_requires=[
+        "h5py",
+        "lalsuite",
+        "matplotlib",
+        "numpy",
+        "scipy",
+    ],
 )
 


### PR DESCRIPTION
This PR adds the `setup_requires` and `install_requires` options to the `setuptools.setup()` function call in `setup.py` to specify the build and runtime requirements respectively.